### PR TITLE
Issue 36 placeables fix

### DIFF
--- a/GameDriver.py
+++ b/GameDriver.py
@@ -3,10 +3,13 @@ from GameResources.Game import Tetros
 game_params = Tetros.display_cli_main_menu()
 while game_params is not None:
     if game_params['display_modes'] != 'main_menu':
+        if 'logging_modes' not in game_params.keys():
+            game_params['logging_modes'] = []
         game = Tetros(game_params['board_size'],
                       game_params['initial_pieces'],
                       game_params['players'],
                       game_params['starting_positions'],
-                      game_params['display_modes'])
+                      game_params['display_modes'],
+                      game_params['logging_modes'])
         game.play_game()
     game_params = Tetros.display_cli_main_menu()

--- a/GameResources/Game.py
+++ b/GameResources/Game.py
@@ -106,7 +106,7 @@ class Tetros:
             for player in self.players:
                 player_dict[player.color] = type(player).__name__
             game_replay_data['players'] = player_dict
-            log_filename = 'Logs/GameReplay' + datetime.now().strftime("%m-%d-%Y-%H-%M-%S") + '.json'
+            log_filename = 'Experiments/Logs/GameReplay' + datetime.now().strftime("%m-%d-%Y-%H-%M-%S") + '.json'
             with open(log_filename, 'w') as write_file:
                 write_file.write(json.dumps(game_replay_data, indent=4))
         if 'end_pause' in self.display_modes:
@@ -399,7 +399,8 @@ class Tetros:
                         'players': ObjectFactory.generate_random_players(),
                         'starting_positions': [[0, 0], [0, 19], [19, 0], [19, 19]],
                         'initial_pieces': ObjectFactory.generate_shapes(),
-                        'display_modes': ['final_board', 'scores', 'end_pause', 'times']
+                        'display_modes': ['final_board', 'scores', 'end_pause', 'times'],
+                        'logging_modes': ['game_replay']
                        }
             if input_string == 'exrandom' or input_string == 'er':
                 print('Simulating game with exhaustive random players...')

--- a/GameResources/Structure.py
+++ b/GameResources/Structure.py
@@ -252,14 +252,12 @@ class GameBoard:
         """
         for x in range(0, len(self.positions)):
             for y in range(0, len(self.positions[0])):
-                pos = self.positions[x][y]
-                if pos.color is not None:
-                    pos.placeable_by = []
-                else:
+                if [x, y] not in self.starting_positions:
+                    self.positions[x][y].placeable_by = []
+                if self.positions[x][y].color is None:
                     for player in players:
-                        if self.check_diagonal_squares(x, y, player.color)\
-                                and not self.check_adjacent_squares(x, y, player.color):
-                            pos.placeable_by.append(player.color)
+                        if self.check_diagonal_squares(x, y, player.color) and not self.check_adjacent_squares(x, y, player.color):
+                            self.positions[x][y].placeable_by.append(player.color)
 
     def place_piece(self, x: int, y: int, piece: GR.Structure.Piece) -> bool:
         """

--- a/GameResources/Structure.py
+++ b/GameResources/Structure.py
@@ -139,7 +139,8 @@ class GameBoard:
             for x in range(0, board_size[0]):
                 row.append(BoardSquare([]))
             self.positions.append(row)
-        self.set_starting_positions(players, starting_positions)
+        self.starting_positions = starting_positions
+        self.set_starting_positions(players)
         self.player_colors = []
         for player in players:
             self.player_colors.append(player.color)
@@ -151,8 +152,7 @@ class GameBoard:
         """
         return len(self.positions), len(self.positions[0])
 
-    def set_starting_positions(self, players: list[GR.SimplePlayers.Player],
-                               starting_positions: list[list[int, int]] = None):
+    def set_starting_positions(self, players: list[GR.SimplePlayers.Player]):
         """
         Set stating positions for players
         Make the locations in starting_positions placeable for corresponding players
@@ -161,11 +161,11 @@ class GameBoard:
         """
         xmax = len(self.positions) - 1
         ymax = len(self.positions[0]) - 1
-        starting_positions = [[0, 0], [xmax, ymax], [0, ymax], [xmax, 0]] \
-            if starting_positions is None else starting_positions
-        random.shuffle(starting_positions)
+        self.starting_positions = [[0, 0], [xmax, ymax], [0, ymax], [xmax, 0]] \
+            if self.starting_positions is None else self.starting_positions
+        random.shuffle(self.starting_positions)
         for i in range(len(players)):
-            x, y = starting_positions[i]
+            x, y = self.starting_positions[i]
             self.positions[x][y].placeable_by.append(players[i].color)
 
     def is_stalemate(self, players: list[GR.SimplePlayers.Player]) -> bool:

--- a/GameResources/Structure.py
+++ b/GameResources/Structure.py
@@ -280,18 +280,27 @@ class GameBoard:
         :param player: If player is specified print the placeable locations for that player
         :return: A Printable representation of the board
         """
-        ret = '_' * ((2 * len(self.positions)) + 3)
+        ret = '     '
+        for col in range(len(self.positions)):
+            ret += f'{col:02} '
+        ret += '\n   '
+        ret += '_' * ((3 * len(self.positions)) + 3)
+        # ret = '_' * ((2 * len(self.positions)) + 3)
         ret += '\n'
-        for y in range(0, len(self.positions[0])):
-            ret += '| '
+        for row in range(0, len(self.positions[0])):
+            ret += f'{row:02} | '
             for x in range(0, len(self.positions)):
-                pos = self.positions[x][y]
+                pos = self.positions[x][row]
                 if pos.color is not None:
-                    ret += colored('▩ ', pos.color)
+                    ret += colored('▩  ', pos.color)
                 elif player is not None and player.color in pos.placeable_by:
-                    ret += colored('▢ ', player.color)
+                    ret += colored('▢  ', player.color)
                 else:
-                    ret += '▢ '
-            ret += '|\n'
-        ret += '‾' * ((2 * len(self.positions)) + 3)
+                    ret += '▢  '
+            ret += f'| {row:02}\n'
+        ret += '   '
+        ret += '‾' * ((3 * len(self.positions)) + 3)
+        ret += '\n     '
+        for col in range(len(self.positions)):
+            ret += f'{col:02} '
         return ret

--- a/GameResources/Structure.py
+++ b/GameResources/Structure.py
@@ -285,7 +285,6 @@ class GameBoard:
             ret += f'{col:02} '
         ret += '\n   '
         ret += '_' * ((3 * len(self.positions)) + 3)
-        # ret = '_' * ((2 * len(self.positions)) + 3)
         ret += '\n'
         for row in range(0, len(self.positions[0])):
             ret += f'{row:02} | '


### PR DESCRIPTION
# Thanks For Your Contribution
## New Features
- Fix #36 
- Board indexing
- Logging for game driver games

## Changes
- Board now stores a reference to the starting positions
- Placeables list is now cleared every turn (except starting positions)
- Board position indexes now printed on all sides of board
- The Game driver now passes logging modes onto the game, this was an oversight on my part

## Checklist
- [x] Have you tested your changes with 100% coverage
- [ ] Is this a new Player type?